### PR TITLE
Fix: Remove unnecessary std::setfill call on istream

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -30,13 +30,13 @@ void cron::Field::parse(const std::string& expression)
 		{
 			std::istringstream range_parser(value_text);
 			lower_bound = -1;
-			range_parser >> std::setfill('-') >> lower_bound;
+			range_parser >> lower_bound;
 			char fill = ' ';
 			range_parser >> fill;
 			if (fill == '-')
 			{
 				upper_bound = -1;
-				range_parser >> std::setfill('-') >> upper_bound;
+				range_parser >> upper_bound;
 			}
 			else
 			{


### PR DESCRIPTION
### Description of the Problem

When parsing the field, `std::setfill` is called on an `istream` object, but this function is meant to be used with `ostream` objects. 

The goal was to make `istream` stop at the `-` character when parsing the number, but it's not needed since `istream` will stop at `-` anyway.

### Proposed Solution

Removed the `std::setfill` call on the `istream` object, as it is unnecessary and incorrect.
